### PR TITLE
Add webhook server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ NOTE: Don't forget to update `shelly_ip` to the IP address of your Shelly relay.
         "pollInterval": 60,
         "username": "garage",
         "password": "Mh4hc7EDJF8mMkzv",
+        "webhookPort": 51828,
         "manufacturer": "BFT",
         "model": "SCE-MA (Board)",
         "statusURL": "http://shelly_ip/status",
@@ -87,6 +88,7 @@ NOTE: Don't forget to update `shelly_ip` to the IP address of your Shelly relay.
 | `http_method`  | HTTP method used to communicate with the device                                                    | `GET`   |
 | `username`     | Username if HTTP authentication is enabled                                                         | N/A     |
 | `password`     | Password if HTTP authentication is enabled                                                         | N/A     |
+| `webhookPort`  | Port for local webhook server triggered at `/garage/update`                     | N/A     |
 | `model`        | Appears under the _Model_ field for the accessory                                                  | plugin  |
 | `serial`       | Appears under the _Serial_ field for the accessory                                                 | version |
 | `manufacturer` | Appears under the _Manufacturer_ field for the accessory                                           | author  |

--- a/config.sample.json
+++ b/config.sample.json
@@ -12,6 +12,7 @@
     "pollInterval": 60,
     "username": "garage",
     "password": "********",
+    "webhookPort": 51828,
     "manufacturer": "BFT",
     "model": "SCE-MA (Board)",
     "statusURL": "http://192.168.1.24/status",

--- a/config.schema.json
+++ b/config.schema.json
@@ -53,6 +53,11 @@
                 "type": "string",
                 "description": "Password if HTTP authentication is enabled"
             },
+            "webhookPort": {
+                "title": "Webhook Port",
+                "type": "integer",
+                "description": "Port for local webhook server listening on /garage/update"
+            },
 
             "openTime": {
                 "title": "Time to open the door",


### PR DESCRIPTION
## Summary
- start a webhook server after Homebridge starts and stop on shutdown
- add `webhookPort` option and use it to launch the server
- call `_getStatus` whenever `/garage/update` is triggered
- document the new option in the README and sample config

## Testing
- `node --check index.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6853e9fba584832cae114f6f303df010